### PR TITLE
Fix security bug in upload-image endpoint

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -21,18 +21,24 @@ app = FastAPI()
 code_space = os.getenv("CODESPACE_NAME")
 app_insights = os.getenv("APPINSIGHTS_CONNECTIONSTRING")
 
-if code_space: 
-    origin_8000= f"https://{code_space}-8000.app.github.dev"
+if code_space:
+    origin_8000 = f"https://{code_space}-8000.app.github.dev"
     origin_5173 = f"https://{code_space}-5173.app.github.dev"
-    ingestion_endpoint = app_insights.split(';')[1].split('=')[1]
-    
-    origins = [origin_8000, origin_5173, os.getenv("API_SERVICE_ACA_URI"), os.getenv("WEB_SERVICE_ACA_URI"), ingestion_endpoint]
+    ingestion_endpoint = app_insights.split(";")[1].split("=")[1]
+
+    origins = [
+        origin_8000,
+        origin_5173,
+        os.getenv("API_SERVICE_ACA_URI"),
+        os.getenv("WEB_SERVICE_ACA_URI"),
+        ingestion_endpoint,
+    ]
 else:
     origins = [
         o.strip()
         for o in Path(Path(__file__).parent / "origins.txt").read_text().splitlines()
     ]
-    origins = ['*']
+    origins = ["*"]
 
 app.add_middleware(
     CORSMiddleware,
@@ -43,6 +49,7 @@ app.add_middleware(
 )
 
 setup_telemetry(app)
+
 
 @app.get("/")
 async def root():
@@ -59,49 +66,66 @@ async def create_article(task: Task):
         media_type="text/event-stream",
     )
 
+
 @app.post("/api/upload-image")
 async def upload_image(file: UploadFile = File(...)):
 
     base = Path(__file__).resolve().parents[1]
 
     # Set the directory for the stored image
-    image_dir = os.path.join(base, 'web/public')
+    image_dir = os.path.join(base, "web/public")
     print(image_dir)
 
-    # Initialize the image path (note the filetype should be png)
-    file_path  = os.path.join(image_dir, file.filename)
-    
+    # Sanitize filename to prevent path traversal
+    filename = os.path.basename(file.filename)
+    file_ext = Path(filename).suffix.lower()
+    allowed_ext = {".png", ".jpg", ".jpeg", ".gif"}
+    if file_ext not in allowed_ext:
+        return JSONResponse({"error": "Unsupported file type"}, status_code=400)
+
+    # Resolve the image path and ensure it stays within image_dir
+    file_path = os.path.abspath(os.path.join(image_dir, filename))
+    if not file_path.startswith(os.path.abspath(image_dir)):
+        return JSONResponse({"error": "Invalid file name"}, status_code=400)
+
     # Save the image to the specified path
     with open(file_path, "wb") as image:
         content = await file.read()
         image.write(content)
 
     project_scope = {
-        "subscription_id": os.environ["AZURE_SUBSCRIPTION_ID"],   
+        "subscription_id": os.environ["AZURE_SUBSCRIPTION_ID"],
         "resource_group_name": os.environ["AZURE_RESOURCE_GROUP"],
-        "project_name": os.environ["AZURE_AI_PROJECT_NAME"],        
+        "project_name": os.environ["AZURE_AI_PROJECT_NAME"],
     }
 
     from evaluate.evaluate import evaluate_image
+
     print(file_path)
     result = evaluate_image(project_scope, file_path)
 
     if len(result) > 0:
         # Return the filename and location
-        return JSONResponse({"filename": file.filename, 
-                             "location": file_path,
-                            "message": f'''
+        return JSONResponse(
+            {
+                "filename": file.filename,
+                "location": file_path,
+                "message": f"""
                             ❌This image contains the following harmful/protected content {result}. 
-                            We do not recommend including it in the blog!❌''',
-                            "safety": ""
-                            })
+                            We do not recommend including it in the blog!❌""",
+                "safety": "",
+            }
+        )
     else:
         # Return the filename and location
-        return JSONResponse({"filename": file.filename, 
-            "location": file_path,
-            "message":"This image is safe to include in the blog ✅",
-            "safety": "Yes this is safe"
-            })
+        return JSONResponse(
+            {
+                "filename": file.filename,
+                "location": file_path,
+                "message": "This image is safe to include in the blog ✅",
+                "safety": "Yes this is safe",
+            }
+        )
 
 
 # TODO: fix open telemetry so it doesn't slow app so much


### PR DESCRIPTION
## Summary
- sanitize uploaded filenames to prevent path traversal
- restrict file extensions for uploaded images

## Testing
- `python -m py_compile src/api/main.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869088d8b108328aa0e4211a3c16085